### PR TITLE
Fix decompression for images that have a height which is more than one block and not a multiple of 4

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -144,7 +144,7 @@ impl Format {
                         let sx = 4 * x + px;
                         let sy = py;
 
-                        if sx < width && sy < height {
+                        if sx < width && (4 * y + sy) < height {
                             for i in 0..4 {
                                 output_row[4 * (sx + sy * width) + i] = rgba[px + py * 4][i];
                             }


### PR DESCRIPTION
The bounds checks for decompression seem to have been copied over from the compression algorithm, but the check has changed because of the block size division